### PR TITLE
feat(opencode): add stow package for global opencode config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,18 @@ bin/.local/bin/python*
 # Skills CLI cache and lockfile (managed by `npx skills`, not user scripts)
 .agents/
 skills-lock.json
+
+# OpenCode local state, caches, and generated files
+.config/opencode/node_modules/
+.config/opencode/package.json
+.config/opencode/package-lock.json
+.config/opencode/.git/
+.config/opencode/.gitignore
+.config/opencode/*.backup-*
+.config/opencode/.ktx/
+.config/opencode/ktx.yaml
+.config/opencode/.omo/
+.config/opencode/plugins/
+.config/opencode/raw-sources/
+.config/opencode/semantic-layer/
+.config/opencode/wiki/

--- a/opencode/.config/opencode/AGENTS.md
+++ b/opencode/.config/opencode/AGENTS.md
@@ -1,0 +1,9 @@
+# Claude-Mem Memory Context
+
+<claude-mem-context>
+# Memory Context from Past Sessions
+
+*No context yet. Complete your first session and context will appear here.*
+
+Use claude-mem search tools for manual memory queries.
+</claude-mem-context>

--- a/opencode/.config/opencode/oh-my-openagent.json
+++ b/opencode/.config/opencode/oh-my-openagent.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
+  "agents": {
+    "sisyphus": {
+      "model": "opencode-go/qwen3.7-plus",
+      "variant": "max",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "hephaestus": {
+      "model": "opencode-go/qwen3.7-plus",
+      "variant": "medium",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "oracle": {
+      "model": "opencode-go/qwen3.7-max",
+      "variant": "high",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "librarian": {
+      "model": "opencode-go/deepseek-v4-flash",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "explore": {
+      "model": "opencode-go/deepseek-v4-flash",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "multimodal-looker": {
+      "model": "opencode-go/kimi-k2.6",
+      "variant": "medium",
+      "fallback_models": [
+        {
+          "model": "opencode-go/deepseek-v4-flash"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "prometheus": {
+      "model": "opencode-go/qwen3.7-max",
+      "variant": "max",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "metis": {
+      "model": "opencode-go/qwen3.7-max",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "momus": {
+      "model": "opencode-go/qwen3.7-max",
+      "variant": "xhigh",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "atlas": {
+      "model": "opencode-go/qwen3.7-plus",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "sisyphus-junior": {
+      "model": "opencode-go/qwen3.7-plus",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    }
+  },
+  "categories": {
+    "visual-engineering": {
+      "model": "opencode-go/qwen3.7-max",
+      "variant": "max",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "ultrabrain": {
+      "model": "opencode-go/qwen3.7-max",
+      "variant": "xhigh",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "deep": {
+      "model": "opencode-go/qwen3.7-max",
+      "variant": "medium",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "artistry": {
+      "model": "opencode-go/qwen3.7-max",
+      "variant": "max",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "quick": {
+      "model": "opencode-go/kimi-k2.6",
+      "fallback_models": [
+        {
+          "model": "opencode-go/deepseek-v4-flash"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "unspecified-low": {
+      "model": "opencode-go/kimi-k2.6",
+      "fallback_models": [
+        {
+          "model": "opencode-go/deepseek-v4-flash"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    },
+    "unspecified-high": {
+      "model": "opencode-go/qwen3.7-max",
+      "fallback_models": [
+        {
+          "model": "opencode-go/kimi-k2.6"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ],
+      "variant": "max"
+    },
+    "writing": {
+      "model": "opencode-go/kimi-k2.6",
+      "fallback_models": [
+        {
+          "model": "opencode-go/deepseek-v4-flash"
+        },
+        {
+          "model": "llmgateway/gpt-5.5"
+        }
+      ]
+    }
+  }
+}

--- a/opencode/.config/opencode/opencode.jsonc
+++ b/opencode/.config/opencode/opencode.jsonc
@@ -1,0 +1,20 @@
+{
+  "plugin": [
+    "oh-my-openagent@latest"
+  ],
+  "provider": {
+    "llmgateway": {
+      "models": {
+        "gpt-5.5": {}
+      }
+    }
+  },
+  "mcp": {
+    "ktx": {
+      "type": "remote",
+      "url": "http://localhost:7878/mcp",
+      "enabled": true
+    }
+  },
+  "$schema": "https://opencode.ai/config.json"
+}


### PR DESCRIPTION
- Track opencode.jsonc, oh-my-openagent.json, and AGENTS.md
- Ignore generated caches, backups, node_modules, and ktx local state
- Stow symlinks now manage the active config files